### PR TITLE
Fix for room names.

### DIFF
--- a/Extension/Model/Chat.swift
+++ b/Extension/Model/Chat.swift
@@ -110,7 +110,7 @@ public class Chat: ObservableObject {
                     print(error)
                 }
             } receiveValue: { response in
-                room.name = response.name
+                room.name = response.name.isEmpty ? nil : response.name
                 self.save()
             })
     }


### PR DESCRIPTION
This is a fix for room names when it is an empty string but not `nil`.